### PR TITLE
Enhance event link support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # AnsarWebsitePlugins
-Plugins for the new wordpress site for Ansare
+Plugins for the new WordPress site for Ansare.
+
+## Simple Upcoming Events
+
+This plugin lets editors create a small list of upcoming events. Each event
+supports an optional link that can point to an external URL **or** to any page
+on the site. Links open in a new tab when rendered via the `[upcoming_events]`
+shortcode.


### PR DESCRIPTION
## Summary
- allow linking to internal pages via dropdown in the event editor
- store selected page ID as meta
- use selected page link in shortcode output
- document plugin usage
- bump plugin version to 1.3

## Testing
- `php -l simple-upcoming-events.php`

------
https://chatgpt.com/codex/tasks/task_e_6875af3704408329875501af61b34a28