### PR TITLE
Add plugin CSS and enqueue

### DIFF
--- a/simple-upcoming-events.css
+++ b/simple-upcoming-events.css
@@ -1,0 +1,50 @@
+.sue-events {
+  background: #e2e2e2;
+  padding: 12px;
+  border-radius: 12px;
+  width: 100%;
+  box-sizing: border-box;
+  color: #fff;
+  font-family: sans-serif;
+}
+
+/* top "X" icon */
+.sue-header {
+  text-align: center;
+  font-size: 24px;
+  margin-bottom: 8px;
+}
+
+/* list reset */
+.sue-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* each item */
+.sue-item {
+  background: #333;
+  border: 1px solid #444;
+  border-radius: 8px;
+  padding: 8px 10px;
+  margin-bottom: 8px;
+  overflow: hidden;
+}
+
+/* title */
+.sue-item .sue-title {
+  display: block;
+  color: #fff;
+  font-weight: bold;
+  text-decoration: none;
+  font-size: 14px;
+  margin-bottom: 4px;
+}
+
+/* description */
+.sue-item .sue-desc {
+  color: #ccc;
+  font-size: 12px;
+  line-height: 1.3;
+}

--- a/simple-upcoming-events.php
+++ b/simple-upcoming-events.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Simple Upcoming Events
  * Description: Add events (title, description, URL or page link) and display the 3 most-recent in a dark, card-style list via [upcoming_events].
- * Version:     1.3
+ * Version:     1.4
  * Author:      You
  */
 
@@ -171,3 +171,15 @@ function sue_upcoming_events_shortcode( $atts ) {
   return ob_get_clean();
 }
 add_shortcode( 'upcoming_events', 'sue_upcoming_events_shortcode' );
+
+// 5) Enqueue plugin styles
+function sue_enqueue_styles() {
+  if ( is_admin() ) return;
+  wp_enqueue_style(
+    'simple-upcoming-events',
+    plugin_dir_url( __FILE__ ) . 'simple-upcoming-events.css',
+    [],
+    '1.0'
+  );
+}
+add_action( 'wp_enqueue_scripts', 'sue_enqueue_styles' );


### PR DESCRIPTION
## Summary
- add dedicated CSS file for Simple Upcoming Events styles
- enqueue the CSS from the plugin

## Testing
- `php -l simple-upcoming-events.php`

------
https://chatgpt.com/codex/tasks/task_e_6877de797444832986aafff6b15d3537