### PR TITLE
Ensure events align to top

### DIFF
--- a/simple-upcoming-events.css
+++ b/simple-upcoming-events.css
@@ -6,6 +6,8 @@
   box-sizing: border-box;
   color: #fff;
   font-family: sans-serif;
+  display: inline-block;
+  vertical-align: top;
 }
 
 /* top "X" icon */

--- a/simple-upcoming-events.php
+++ b/simple-upcoming-events.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Simple Upcoming Events
  * Description: Add events (title, description, URL or page link) and display the 3 most-recent in a dark, card-style list via [upcoming_events].
- * Version:     1.4
+ * Version:     1.5
  * Author:      You
  */
 


### PR DESCRIPTION
## Summary
- make event block align from the top by default
- bump plugin version to 1.5

## Testing
- `php -l simple-upcoming-events.php`

------
https://chatgpt.com/codex/tasks/task_e_6877f21045908329b5d3e795ba30700d