### PR TITLE
Fix interactive map forms using base URL

### DIFF
--- a/interactive-us-map.php
+++ b/interactive-us-map.php
@@ -71,7 +71,7 @@ function iusm_settings_page() {
         <h1>Interactive US Map</h1>
 
         <h2>API Key</h2>
-        <form method="post">
+        <form method="post" action="<?php echo esc_url( admin_url( 'admin.php?page=iusm' ) ); ?>">
             <?php wp_nonce_field( 'iusm_save_api' ); ?>
             <p>
                 <label for="iusm_api_key">Google Maps API Key:</label>
@@ -107,7 +107,7 @@ function iusm_settings_page() {
         </table>
 
         <h2>Add New City</h2>
-        <form method="post">
+        <form method="post" action="<?php echo esc_url( admin_url( 'admin.php?page=iusm' ) ); ?>">
             <?php wp_nonce_field( 'iusm_save_city' ); ?>
             <table class="form-table" style="max-width:600px;">
                 <tr>


### PR DESCRIPTION
## Summary
- ensure both admin forms submit to the base map settings page

## Testing
- `php -l interactive-us-map.php`
- `php -l simple-upcoming-events.php`


------
https://chatgpt.com/codex/tasks/task_e_687f8a88bebc8329bfea8a443b55f290