### PR TITLE
Fix map init

### DIFF
--- a/interactive-us-map.php
+++ b/interactive-us-map.php
@@ -153,7 +153,7 @@ function iusm_render_map() {
     wp_enqueue_style( 'interactive-us-map', plugin_dir_url( __FILE__ ) . 'interactive-us-map.css', [], '1.0' );
     $handle = 'google-maps';
     if ( ! wp_script_is( $handle, 'enqueued' ) ) {
-        $src = 'https://maps.googleapis.com/maps/api/js?key=' . esc_attr( $api_key ) . '&callback=initIUSMMap';
+        $src = 'https://maps.googleapis.com/maps/api/js?key=' . esc_attr( $api_key );
         wp_enqueue_script( $handle, $src, [], null, true );
     }
     wp_enqueue_script( 'iusm-map', plugin_dir_url( __FILE__ ) . 'interactive-us-map.js', [ $handle ], '1.0', true );


### PR DESCRIPTION
## Summary
- remove callback parameter when loading the Google Maps script

This ensures the map initializes after the script loads, preventing an `initIUSMMap` is not a function error.

## Testing
- `php -l interactive-us-map.php`


------
https://chatgpt.com/codex/tasks/task_e_687f904f77908329b770ae341a4e623e