### PR TITLE
Remove photo backgrounds from leadership accordion

### DIFF
--- a/leadership-accordion.html
+++ b/leadership-accordion.html
@@ -74,29 +74,6 @@
     flex: 6;
   }
 
-  .leadership-container .accordion-panel .background {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-size: cover;
-    background-position: center;
-    transition: transform 0.6s ease-out, filter 0.6s ease;
-    filter: brightness(0.7);
-    z-index: 0;
-  }
-
-  .leadership-container .accordion-panel:hover .background:not(.active .background) {
-    filter: brightness(0.9);
-    transform: scale(1.05);
-  }
-
-  .leadership-container .accordion-panel.active .background {
-    filter: brightness(0.85);
-    transform: scale(1);
-  }
-
   .leadership-container .accordion-panel .title {
     writing-mode: vertical-lr;
     transform: rotate(180deg);
@@ -278,18 +255,17 @@
   <div class="accordion-container">
     <!-- Regional Director -->
     <div class="accordion-panel active" data-role="regional-director">
-      <div class="background" style="background-image: url('https://via.placeholder.com/900x600/1f3a7a/ffffff?text=Zahid+Mian');"></div>
       <div class="pulsing-dot"></div>
       <div class="title">Regional Director</div>
       <div class="panel-content">
         <div class="profile-item">
           <div class="profile-info">
-            <h3>Zahid Mian</h3>
-            <p>Oversees the Central-East region and provides strategic leadership to community directors.</p>
+            <h3>Anas Ahmed Mirza</h3>
+            <p>Nāzim Aala Central East Region</p>
           </div>
           <div class="profile-meta">
             <div class="label">Email</div>
-            <div class="value"><a href="mailto:zahid.mian@ansarusa.org" style="color:#fff;text-decoration:underline;">zahid.mian@ansarusa.org</a></div>
+            <div class="value"><a href="mailto:nazim.ce@ansarusa.org" style="color:#fff;text-decoration:underline;">nazim.ce@ansarusa.org</a></div>
             <div class="label">Region</div>
             <div class="value">Central-East</div>
           </div>
@@ -299,38 +275,23 @@
             <h3>Responsibilities</h3>
             <p>Coordinate regional events, mentor community directors, and liaise with national leadership.</p>
           </div>
-          <div class="profile-meta">
-            <div class="label">Term</div>
-            <div class="value">2024–2026</div>
-          </div>
-        </div>
-        <div class="profile-item">
-          <div class="profile-info">
-            <h3>Strategy</h3>
-            <p>Strengthen collaboration across communities and improve leadership training pipelines.</p>
-          </div>
-          <div class="profile-meta">
-            <div class="label">Priority</div>
-            <div class="value">Growth & Alignment</div>
-          </div>
         </div>
       </div>
     </div>
 
     <!-- Central Jersey Director -->
     <div class="accordion-panel" data-role="central-jersey-director">
-      <div class="background" style="background-image: url('https://via.placeholder.com/900x600/2E294E/ffffff?text=Adil+Mian');"></div>
       <div class="pulsing-dot"></div>
       <div class="title">Director Central Jersey</div>
       <div class="panel-content">
         <div class="profile-item">
           <div class="profile-info">
-            <h3>Adil Mian</h3>
+            <h3>Masroor Sajid</h3>
             <p>Leads the Central Jersey community with focus on strengthening local engagement and mentorship.</p>
           </div>
           <div class="profile-meta">
             <div class="label">Email</div>
-            <div class="value"><a href="mailto:adil.mian@ansarusa.org" style="color:#fff;text-decoration:underline;">adil.mian@ansarusa.org</a></div>
+            <div class="value"><a href="mailto:zaim.centraljersey@ansarusa.org" style="color:#fff;text-decoration:underline;">zaim.centraljersey@ansarusa.org</a></div>
             <div class="label">Community</div>
             <div class="value">Central Jersey</div>
           </div>
@@ -350,18 +311,17 @@
 
     <!-- North Jersey Director -->
     <div class="accordion-panel" data-role="north-jersey-director">
-      <div class="background" style="background-image: url('https://via.placeholder.com/900x600/4F6D7A/ffffff?text=Ahmed+Khan');"></div>
       <div class="pulsing-dot"></div>
       <div class="title">Director North Jersey</div>
       <div class="panel-content">
         <div class="profile-item">
           <div class="profile-info">
-            <h3>Ahmed Khan</h3>
+            <h3>Naseer Alam</h3>
             <p>Focuses on inter-community collaboration and leadership development in North Jersey.</p>
           </div>
           <div class="profile-meta">
             <div class="label">Email</div>
-            <div class="value"><a href="mailto:ahmed.khan@ansarusa.org" style="color:#fff;text-decoration:underline;">ahmed.khan@ansarusa.org</a></div>
+            <div class="value"><a href="mailto:Zaim.northjersey@ansarusa.org" style="color:#fff;text-decoration:underline;">Zaim.northjersey@ansarusa.org</a></div>
             <div class="label">Community</div>
             <div class="value">North Jersey</div>
           </div>
@@ -381,18 +341,17 @@
 
     <!-- Willingboro Director -->
     <div class="accordion-panel" data-role="willingboro-director">
-      <div class="background" style="background-image: url('https://via.placeholder.com/900x600/007d8c/ffffff?text=Omar+Malik');"></div>
       <div class="pulsing-dot"></div>
       <div class="title">Director Willingboro</div>
       <div class="panel-content">
         <div class="profile-item">
           <div class="profile-info">
-            <h3>Omar Malik</h3>
+            <h3>Hamid Masood Bajwa</h3>
             <p>Coordinates local outreach and strengthens community ties in Willingboro.</p>
           </div>
           <div class="profile-meta">
             <div class="label">Email</div>
-            <div class="value"><a href="mailto:omar.malik@ansarusa.org" style="color:#fff;text-decoration:underline;">omar.malik@ansarusa.org</a></div>
+            <div class="value"><a href="mailto:zaim.Willingboro@ansarusa.org" style="color:#fff;text-decoration:underline;">zaim.Willingboro@ansarusa.org</a></div>
             <div class="label">Community</div>
             <div class="value">Willingboro</div>
           </div>
@@ -412,18 +371,17 @@
 
     <!-- Lehigh Valley Director -->
     <div class="accordion-panel" data-role="lehigh-valley-director">
-      <div class="background" style="background-image: url('https://via.placeholder.com/900x600/8A2BE2/ffffff?text=Athar+Malik');"></div>
       <div class="pulsing-dot"></div>
       <div class="title">Director Lehigh Valley</div>
       <div class="panel-content">
         <div class="profile-item">
           <div class="profile-info">
-            <h3>Athar Malik</h3>
+            <h3>Essam Ahmed Arshed</h3>
             <p>Leads Lehigh Valley’s initiatives with a focus on leadership training and regional coordination.</p>
           </div>
           <div class="profile-meta">
             <div class="label">Email</div>
-            <div class="value"><a href="mailto:athar.malik@ansarusa.org" style="color:#fff;text-decoration:underline;">athar.malik@ansarusa.org</a></div>
+            <div class="value"><a href="mailto:zaim.LehighValley@ansarusa.org" style="color:#fff;text-decoration:underline;">zaim.LehighValley@ansarusa.org</a></div>
             <div class="label">Community</div>
             <div class="value">Lehigh Valley</div>
           </div>
@@ -443,18 +401,17 @@
 
     <!-- Philadelphia Director -->
     <div class="accordion-panel" data-role="philadelphia-director">
-      <div class="background" style="background-image: url('https://via.placeholder.com/900x600/DAA520/ffffff?text=Ahmed+Malik');"></div>
       <div class="pulsing-dot"></div>
       <div class="title">Director Philadelphia</div>
       <div class="panel-content">
         <div class="profile-item">
           <div class="profile-info">
-            <h3>Ahmed Malik</h3>
+            <h3>Niaz Malik</h3>
             <p>Responsible for leading Philadelphia community efforts and strategic regional alignment.</p>
           </div>
           <div class="profile-meta">
             <div class="label">Email</div>
-            <div class="value"><a href="mailto:ahmed.malik@ansarusa.org" style="color:#fff;text-decoration:underline;">ahmed.malik@ansarusa.org</a></div>
+            <div class="value"><a href="mailto:zaim.philadelphia@ansarusa.org" style="color:#fff;text-decoration:underline;">zaim.philadelphia@ansarusa.org</a></div>
             <div class="label">Community</div>
             <div class="value">Philadelphia</div>
           </div>
@@ -484,11 +441,7 @@
     const panels = Array.from(container.querySelectorAll('.accordion-panel'));
 
     function clearActive() {
-      panels.forEach(p => {
-        p.classList.remove('active');
-        const bg = p.querySelector('.background');
-        if (bg) bg.style.transform = '';
-      });
+      panels.forEach(p => p.classList.remove('active'));
     }
     function activate(panel) {
       clearActive();
@@ -504,11 +457,6 @@
           activate(panel);
         }
       });
-      const bg = panel.querySelector('.background');
-      if (bg) {
-        const url = bg.style.backgroundImage.slice(4, -1).replace(/"/g, "");
-        new Image().src = url;
-      }
       panel.addEventListener('touchend', () => activate(panel));
     });
 
@@ -518,18 +466,6 @@
       const randomIndex = Math.floor(Math.random() * panels.length);
       activate(panels[randomIndex]);
     }
-
-    document.addEventListener('mousemove', function(e) {
-      const active = container.querySelector('.accordion-panel.active');
-      if (active) {
-        const background = active.querySelector('.background');
-        if (background) {
-          const mouseX = e.clientX / window.innerWidth;
-          const mouseY = e.clientY / window.innerHeight;
-          background.style.transform = `scale(1.05) translate(${mouseX * -10}px, ${mouseY * -10}px)`;
-        }
-      }
-    });
 
     function handleResize() {
       const accordion = container.querySelector('.accordion-container');


### PR DESCRIPTION
## Summary
- replace leadership accordion markup and content
- drop background image elements to remove photo space from profile panels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688f9813a2c48329a01bdefcd57ee745