### PR TITLE
Fix leadership accordion mobile layout

### DIFF
--- a/leadership-accordion.html
+++ b/leadership-accordion.html
@@ -233,12 +233,20 @@
     }
 
     .leadership-container .accordion-panel {
-      min-height: 140px;
+      flex: 0 0 auto;
+      min-height: 220px;
+      align-items: flex-start;
     }
 
     .leadership-container .accordion-panel .title {
       font-size: 1.4rem;
       padding: 15px 10px;
+      writing-mode: horizontal-tb;
+      transform: none;
+    }
+
+    .leadership-container .accordion-panel.active {
+      flex: 0 0 auto;
     }
 
     .leadership-container .accordion-panel.active .title {


### PR DESCRIPTION
## Summary
- Expand mobile accordion panels and remove flex-based sizing
- Show titles horizontally and top-aligned on small screens

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68956ccec80c8329a03c69e7231dc583