### PR TITLE
Adjust title layering in leadership accordion

### DIFF
--- a/leadership-accordion.html
+++ b/leadership-accordion.html
@@ -253,6 +253,15 @@
       font-size: 1.6rem;
     }
   }
+
+  @media (max-width: 500px) {
+    .leadership-container .accordion-panel .title {
+      z-index: 1;
+    }
+    .leadership-container .panel-content {
+      z-index: 2;
+    }
+  }
 </style>
 
 <div class="leadership-container">


### PR DESCRIPTION
## Summary
- Restore original z-index layering for the accordion title and panel content on larger screens
- Add mobile-only media query to invert z-index so headings don’t overlap panel content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689573a45820832989f74d36e73e59fb